### PR TITLE
!fixup: OmniJaws: Add themed outline icon resources

### DIFF
--- a/app/src/main/java/org/omnirom/omnijaws/widget/WeatherAppWidgetProvider.java
+++ b/app/src/main/java/org/omnirom/omnijaws/widget/WeatherAppWidgetProvider.java
@@ -327,6 +327,25 @@ public class WeatherAppWidgetProvider extends AppWidgetProvider {
                 && iconPack.supportsTheming
                 && iconPack.canUseLocalResources(context);
 
+        switch (theme) {
+            case COLOR_THEME_SYSTEM:
+                smallWidgetResId = R.layout.weather_appwidget_small_system;
+                largelWidgetResId = R.layout.weather_appwidget_large_system;
+                wideWidgetResId = R.layout.weather_appwidget_wide_system;
+                break;
+            case COLOR_THEME_DARK:
+                smallWidgetResId = R.layout.weather_appwidget_small_dark;
+                largelWidgetResId = R.layout.weather_appwidget_large_dark;
+                wideWidgetResId = R.layout.weather_appwidget_wide_dark;
+                break;
+            case COLOR_THEME_LIGHT:
+                smallWidgetResId = R.layout.weather_appwidget_small_light;
+                largelWidgetResId = R.layout.weather_appwidget_large_light;
+                wideWidgetResId = R.layout.weather_appwidget_wide_light;
+                break;
+        }
+
+
         RemoteViews smallView = new RemoteViews(context.getPackageName(), smallWidgetResId);
         setupRemoteView(context, appWidgetManager, appWidgetId, smallView,
                 bgTrans, iconPack, useResourceIcon, iconNightMode);


### PR DESCRIPTION
Without the switch-case the widgets theme always follows system.

Completely removing the switch-case-statement, as done in commit 2f7bbac2299eb898e19429c8a351e8394f6364d6,  breaks the widget theming, and therefore always uses the (default) follow-system-setting.